### PR TITLE
test: add available pets test with status validation

### DIFF
--- a/src/test/java/com/automationProject/model/category/Category.java
+++ b/src/test/java/com/automationProject/model/category/Category.java
@@ -1,0 +1,17 @@
+package com.automationProject.model.category;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Category {
+
+    private Long id;
+    private String name;
+
+}

--- a/src/test/java/com/automationProject/model/pet/AvailablePetResponse.java
+++ b/src/test/java/com/automationProject/model/pet/AvailablePetResponse.java
@@ -1,0 +1,18 @@
+package com.automationProject.model.pet;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AvailablePetResponse {
+
+    private List<Pet> pets;
+
+}

--- a/src/test/java/com/automationProject/model/pet/AvailablePetRquest.java
+++ b/src/test/java/com/automationProject/model/pet/AvailablePetRquest.java
@@ -1,0 +1,16 @@
+package com.automationProject.model.pet;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AvailablePetRquest {
+
+    private String status;
+
+}

--- a/src/test/java/com/automationProject/model/pet/Pet.java
+++ b/src/test/java/com/automationProject/model/pet/Pet.java
@@ -1,0 +1,23 @@
+package com.automationProject.model.pet;
+
+import com.automationProject.model.category.Category;
+import com.automationProject.model.tag.Tag;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Pet {
+    private Long id;
+    private Category category;
+    private String name;
+    private List<String> photoUrls;
+    private List<Tag> tags;
+    private String status;
+}

--- a/src/test/java/com/automationProject/model/tag/Tag.java
+++ b/src/test/java/com/automationProject/model/tag/Tag.java
@@ -1,0 +1,17 @@
+package com.automationProject.model.tag;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Tag {
+
+    private Long id;
+    private String name;
+
+}

--- a/src/test/java/com/automationProject/tests/AvailablePetTests.java
+++ b/src/test/java/com/automationProject/tests/AvailablePetTests.java
@@ -1,0 +1,34 @@
+package com.automationProject.tests;
+
+import com.automationProject.config.TestRunner;
+import com.automationProject.model.pet.Pet;
+import com.automationProject.request.RequestBuilder;
+import io.restassured.common.mapper.TypeRef;
+import jdk.internal.org.objectweb.asm.TypeReference;
+import org.testng.annotations.Test;
+import io.restassured.response.Response;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.*;
+
+public class AvailablePetTests extends TestRunner {
+
+    @Test(testName = "Get all pets with Available status")
+    public void GetAllPetsWithAvailableStatus(){
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("status", "available");
+
+        Response response = RequestBuilder.getRequestWithQueryParams(getBaseUrl(), "pet/findByStatus", queryParams, getApiKey());
+        List<Pet> pets = response.as(new TypeRef<List<Pet>>() {});
+
+        assertEquals(response.getStatusCode(), 200, "Status code not as expected");
+        assertFalse(pets.isEmpty(), "The pets list should not be empty");
+        for (int i = 0; i < pets.size(); i++) {
+            assertEquals(pets.get(i).getStatus(), "available", "the status should match");
+        }
+
+    }
+}


### PR DESCRIPTION
**Description**

This PR adds a new test case to validate the GET /pet/findByStatus endpoint from the Swagger Petstore API.
The test ensures that when requesting pets with the status "available", the response returns a non-empty list of pets, all of which should have the expected status.

**Changes Introduced**

Added AvailablePetTests class under com.automationProject.tests.

Implemented test GetAllPetsWithAvailableStatus that:

Sends a GET request with query param status=available.

Maps the response into a List<Pet> model.

Validates that the response status code is 200.

Asserts that the pets list is not empty.

Ensures that returned pets have "available" as their status.

**Test Evidence**

✅ GET /pet/findByStatus?status=available returns 200 OK.
✅ Response contains a non-empty list of pets.
✅ Each pet in the list has status = available.