### PR TITLE
test: add GetPetByID test to validate fetching a specific pet by ID

### DIFF
--- a/src/test/java/com/automationProject/model/pet/AvailablePetRequest.java
+++ b/src/test/java/com/automationProject/model/pet/AvailablePetRequest.java
@@ -1,0 +1,16 @@
+package com.automationProject.model.pet;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AvailablePetRequest {
+
+    private String status;
+
+}

--- a/src/test/java/com/automationProject/model/pet/GetPetByIdRequest.java
+++ b/src/test/java/com/automationProject/model/pet/GetPetByIdRequest.java
@@ -9,8 +9,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class AvailablePetRquest {
+public class GetPetByIdRequest {
 
-    private String status;
+    private int id;
 
 }

--- a/src/test/java/com/automationProject/model/pet/Pet.java
+++ b/src/test/java/com/automationProject/model/pet/Pet.java
@@ -2,6 +2,7 @@ package com.automationProject.model.pet;
 
 import com.automationProject.model.category.Category;
 import com.automationProject.model.tag.Tag;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,6 +14,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Pet {
     private Long id;
     private Category category;

--- a/src/test/java/com/automationProject/request/RequestBuilder.java
+++ b/src/test/java/com/automationProject/request/RequestBuilder.java
@@ -22,35 +22,6 @@ public class RequestBuilder {
         return  requestSpecification.get(path);
     }
 
-    public static Response getRequest(String baseUrl, String path, String apiKey) {
-        RequestSpecification requestSpecification = RestAssured.given()
-                .baseUri(baseUrl)
-                .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
-                .filter(new RequestLoggingFilter())
-                .filter(new ResponseLoggingFilter());
-
-        if (apiKey != null) {
-            requestSpecification.header("special-key", apiKey);
-        }
-
-        return  requestSpecification.get(path);
-    }
-
-    public static Response getRequest(String baseUrl, String path, Object body, String apiKey) {
-        RequestSpecification requestSpecification = RestAssured.given()
-                .baseUri(baseUrl)
-                .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
-                .filter(new RequestLoggingFilter())
-                .filter(new ResponseLoggingFilter())
-                .body(body);
-
-        if (apiKey != null) {
-            requestSpecification.header("special-key", apiKey);
-        }
-
-        return  requestSpecification.get(path);
-    }
-
     public static Response getRequestWithQueryParams(String baseUrl, String path, Map<String, String> queryParams, String apiKey) {
         RequestSpecification requestSpecification = RestAssured.given()
                 .baseUri(baseUrl)
@@ -59,6 +30,21 @@ public class RequestBuilder {
                 .filter(new RequestLoggingFilter())
                 .filter(new ResponseLoggingFilter())
                 .queryParams(queryParams);
+
+        if (apiKey != null) {
+            requestSpecification.header("special-key", apiKey);
+        }
+
+        return requestSpecification.get();
+    }
+    public static Response getRequestWithQueryParams(String baseUrl, String path, String name,int queryParam, String apiKey) {
+        RequestSpecification requestSpecification = RestAssured.given()
+                .baseUri(baseUrl)
+                .basePath(path)
+                .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+                .filter(new RequestLoggingFilter())
+                .filter(new ResponseLoggingFilter())
+                .pathParam(name,queryParam);
 
         if (apiKey != null) {
             requestSpecification.header("special-key", apiKey);
@@ -80,21 +66,5 @@ public class RequestBuilder {
         }
 
         return  requestSpecification.post(path);
-    }
-
-    public static Response deleteRequest(String baseUrl, String path, Integer id, String apiKey) {
-        RequestSpecification requestSpecification = RestAssured.given()
-                .baseUri(baseUrl)
-                .basePath(path)
-                .header(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
-                .filter(new RequestLoggingFilter())
-                .filter(new ResponseLoggingFilter())
-                .pathParams("id", id);
-
-        if (apiKey != null) {
-            requestSpecification.header("special-key", apiKey);
-        }
-
-        return  requestSpecification.delete("/{id}");
     }
 }

--- a/src/test/java/com/automationProject/tests/GetPetByIDTests.java
+++ b/src/test/java/com/automationProject/tests/GetPetByIDTests.java
@@ -1,0 +1,23 @@
+package com.automationProject.tests;
+
+import com.automationProject.config.TestRunner;
+import com.automationProject.model.pet.Pet;
+import com.automationProject.request.RequestBuilder;
+import org.testng.annotations.Test;
+import io.restassured.response.Response;
+
+import static org.testng.Assert.assertEquals;
+
+public class GetPetByIDTests extends TestRunner {
+
+    @Test(testName = "Get data from a specific pet")
+    public void getPetByID() {
+        int petId = 2;
+
+        Response response = RequestBuilder.getRequestWithQueryParams(getBaseUrl(), "/pet/{petId}","petId", petId, getApiKey());
+        Pet pet = response.as(Pet.class);
+
+        assertEquals(response.getStatusCode(), 200, "The status code doesn't match the expected status code.");
+        assertEquals(pet.getId(), 2, "The pet ID doesn't match the expected pet ID.");
+    }
+}


### PR DESCRIPTION
**Description**

This PR introduces a new test case that validates the GET /pet/{petId} endpoint from the PetStore API.
The test ensures that:

The API responds with HTTP 200 OK.

The returned pet object matches the expected petId.

**Changes**

Added GetPetByIDTests class in com.automationProject.tests.

Implemented validation for:

Response status code.

Correct petId in the response body.